### PR TITLE
Add AGENTS.md for cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+## Cursor Cloud specific instructions
+
+### Overview
+CineVerse is a static frontend movie discovery PWA (HTML/CSS/vanilla JS). There is **no build step**, no package manager, no backend, no database, and no test framework. All movie data comes from the TMDB API (key hardcoded in `script.js`).
+
+### Running the dev server
+Serve the repo root with any static HTTP server. The Service Worker (`sw.js`) and some browser APIs require HTTP, not `file://`.
+
+```
+python3 -m http.server 8000
+```
+
+Then open `http://localhost:8000/` in a browser.
+
+### Lint / Test / Build
+There are no lint, test, or build commands configured in this repo. There is no `package.json`, `Makefile`, or CI config.
+
+### Key files
+| File | Purpose |
+|---|---|
+| `index.html` | Main entry point |
+| `script.js` | All application logic and TMDB API integration |
+| `styles.css` | Styling |
+| `sw.js` | Service Worker for PWA offline caching |
+| `manifest.json` | PWA manifest |
+
+### Gotchas
+- The TMDB API key is hardcoded in `script.js` line 5. If it stops working, a new key can be obtained from https://www.themoviedb.org/.
+- Several alternate HTML files exist (`index_new.html`, `index_broken.html`, `index_fixed.html`, `dev.html`, `test-modal.html`) — these are development/debug variants, not the main entry point.
+- The watchlist is stored in `localStorage` — clearing browser data resets it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for developing in this static frontend codebase.

### What's included
- Overview of the project (static HTML/CSS/JS PWA, no build step)
- How to run the dev server (`python3 -m http.server 8000`)
- Key files reference table
- Gotchas for future agents (TMDB API key location, alternate HTML files, localStorage watchlist)

### Environment verification
The dev environment was verified end-to-end:
- Static file server serves `index.html` correctly
- TMDB API is reachable and returns movie data
- Core features tested: trending movies, search, movie details modal, watchlist

[cineverse_demo_search_watchlist.mp4](https://cursor.com/agents/bc-42e5184c-577f-4713-a7ca-5d77d3bf4075/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcineverse_demo_search_watchlist.mp4)
Demo showing search for "The Dark Knight", viewing movie details, adding to watchlist, and viewing the watchlist.

[CineVerse homepage](https://cursor.com/agents/bc-42e5184c-577f-4713-a7ca-5d77d3bf4075/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcineverse_homepage.webp)
[Movie details modal](https://cursor.com/agents/bc-42e5184c-577f-4713-a7ca-5d77d3bf4075/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmovie_details_modal.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42e5184c-577f-4713-a7ca-5d77d3bf4075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42e5184c-577f-4713-a7ca-5d77d3bf4075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

